### PR TITLE
Parse flags from environment variables as well

### DIFF
--- a/chatoops/cmd/chatoopsd/services-gen.go
+++ b/chatoops/cmd/chatoopsd/services-gen.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"os"
+	"strings"
 
 	"github.com/sr/operator"
 	"google.golang.org/grpc"
@@ -31,9 +32,19 @@ func registerServices(
 	flags.StringVar(&gcloudConfig.ServiceAccountEmail, "gcloud-service_account_email", "", "")
 	flags.StringVar(&gcloudConfig.StartupScript, "gcloud-startup_script", "", "")
 	flags.StringVar(&papertrailConfig.ApiKey, "papertrail-api_key", "", "")
+	flags.VisitAll(func(f *flag.Flag) {
+		k := strings.ToUpper(strings.Replace(f.Name, "-", "_", -1))
+		v := os.Getenv(k)
+		if v != "" {
+			if err := f.Value.Set(v); err != nil {
+				return err
+			}
+		}
+	})
 	if err := flags.Parse(os.Args[1:]); err != nil {
 		return err
 	}
+
 	errs := make(map[string][]error)
 
 	if buildkiteConfig.ApiToken == "" {

--- a/chatoops/cmd/chatoopsd/services-gen.go
+++ b/chatoops/cmd/chatoopsd/services-gen.go
@@ -32,21 +32,19 @@ func registerServices(
 	flags.StringVar(&gcloudConfig.ServiceAccountEmail, "gcloud-service_account_email", "", "")
 	flags.StringVar(&gcloudConfig.StartupScript, "gcloud-startup_script", "", "")
 	flags.StringVar(&papertrailConfig.ApiKey, "papertrail-api_key", "", "")
+	errs := make(map[string][]error)
 	flags.VisitAll(func(f *flag.Flag) {
 		k := strings.ToUpper(strings.Replace(f.Name, "-", "_", -1))
 		v := os.Getenv(k)
 		if v != "" {
 			if err := f.Value.Set(v); err != nil {
-				return err
+				errs["envflags"] = append(errs["envflags"], err)
 			}
 		}
 	})
 	if err := flags.Parse(os.Args[1:]); err != nil {
 		return err
 	}
-
-	errs := make(map[string][]error)
-
 	if buildkiteConfig.ApiToken == "" {
 		errs["buildkite"] = append(errs["buildkite"], errors.New("api_token"))
 	}

--- a/cmd/protoc-gen-operatord/template.go
+++ b/cmd/protoc-gen-operatord/template.go
@@ -33,6 +33,15 @@ func registerServices(
 	flags.StringVar(&{{$serviceName}}Config.{{camelCase .Name}}, "{{$serviceName}}-{{.Name}}", "", "")
 	{{- end}}
 {{- end}}
+	flags.VisitAll(func(f *flag.Flag) {
+		k := strings.ToUpper(strings.Replace(f.Name, "-", "_", -1))
+		v := os.Getenv(k)
+		if v != "" {
+			if err := f.Value.Set(v); err != nil {
+				return err
+			}
+		}
+	})
 	if err := flags.Parse(os.Args[1:]); err != nil {
 		return err
 	}

--- a/cmd/protoc-gen-operatord/template.go
+++ b/cmd/protoc-gen-operatord/template.go
@@ -33,19 +33,19 @@ func registerServices(
 	flags.StringVar(&{{$serviceName}}Config.{{camelCase .Name}}, "{{$serviceName}}-{{.Name}}", "", "")
 	{{- end}}
 {{- end}}
+	errs := make(map[string][]error)
 	flags.VisitAll(func(f *flag.Flag) {
 		k := strings.ToUpper(strings.Replace(f.Name, "-", "_", -1))
 		v := os.Getenv(k)
 		if v != "" {
 			if err := f.Value.Set(v); err != nil {
-				return err
+				errs["envflags"] = append(errs["envflags"], err)
 			}
 		}
 	})
 	if err := flags.Parse(os.Args[1:]); err != nil {
 		return err
 	}
-	errs := make(map[string][]error)
 {{range .Services}}
 	{{- $serviceName := .Name }}
 	{{- range .Config}}


### PR DESCRIPTION
This will let us choose how we pass vars in, based on what we prefer
Command line flags are granted precendence. Flags are converted to
env var style by converting `-` to `_` and upcasing the var.

```
$ BUILDKITE_API_TOKEN=envvar chatoopsd -buildkite-api_token=cmdline
bkapi: cmdline
$ BUILDKITE_API_TOKEN=envvar chatoopsd
bkapi: envvar
```