### PR TITLE
Add description to arguments, pass argument type through

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -16,6 +16,7 @@ import (
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 )
 
 const undocumentedPlaceholder = "Undocumented"
@@ -50,6 +51,9 @@ type Method struct {
 type Argument struct {
 	Name        string
 	Description string
+	Type        descriptor.FieldDescriptorProto_Type
+	messageIdx  int
+	fieldNum    int32
 }
 
 type File struct {


### PR DESCRIPTION
This parses the comments and loads descriptions for field arguments. It also passes the type of the argument on in the Argument struct for use elsewhere. This provides the foundations for richer type support in generation.